### PR TITLE
Switch PI to M_PI to support STRICT_R_HEADERS

### DIFF
--- a/src/ToolsC_martingale.cpp
+++ b/src/ToolsC_martingale.cpp
@@ -48,7 +48,7 @@ Eigen::MatrixXd MartG_XiC(int n, int k,int p, int B, double bn, int ken_sign){
       for(int j=0; j<n-k; j++){
         if(i!=j){
           double temp =double(i-j)/bn;
-          kenel(i,j) = 25/(12*PI*PI*temp*temp) * (sin(6*PI*temp/5)/(6*PI*temp/5) - cos(6*PI*temp/5));
+          kenel(i,j) = 25/(12*M_PI*M_PI*temp*temp) * (sin(6*M_PI*temp/5)/(6*M_PI*temp/5) - cos(6*M_PI*temp/5));
           }
         }
       }

--- a/src/toolsC_wntest.cpp
+++ b/src/toolsC_wntest.cpp
@@ -55,7 +55,7 @@ Eigen::MatrixXd WN_XiC(int n, int k,int p, int B, double bn, int ken_sign){
       for(int j=0; j<n-k; j++){
         if(i!=j){
           double temp =double(i-j)/bn;
-          kenel(i,j) = 25/(12*PI*PI*temp*temp) * (sin(6*PI*temp/5)/(6*PI*temp/5) - cos(6*PI*temp/5));
+          kenel(i,j) = 25/(12*M_PI*M_PI*temp*temp) * (sin(6*M_PI*temp/5)/(6*M_PI*temp/5) - cos(6*M_PI*temp/5));
         }
       }
     }


### PR DESCRIPTION
Dear Chen, dear HDTSA team,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history.

Your package uses (in two files) PI (instead of the standard C define M_PI, or e.g. the newer Armadillo constant arma::datum::pi) and PI goes away when we set STRICT_R_HEADERS (as a #define in a header or source file, a -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do). We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

This very simple PR changes PI to M_PI in two files. Your code will then work with and without STRICT_R_HEADERS (as M_PI is an old define from C). But PI only works when STRICT_R_HEADERS is not defined, which we plan to change to.

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.